### PR TITLE
Fixed typo from "Exaple" to "Example"

### DIFF
--- a/examples/src/ExamplePage.js
+++ b/examples/src/ExamplePage.js
@@ -14,7 +14,7 @@ import {
 import config from "./config";
 import MicrosoftLogin from "../../dist";
 
-const ExaplePage = () => {
+const ExamplePage = () => {
   const [msalInstance, onMsalInstanceChange] = useState();
   const [clientId, onClientIdChange] = useState(config.client_id);
   const [callbackUrl, onCallbackUrlChange] = useState(
@@ -202,4 +202,4 @@ const ExaplePage = () => {
   );
 };
 
-export default ExaplePage;
+export default ExamplePage;


### PR DESCRIPTION
Updated the variable name and default export to match import in index.js