### PR TITLE
Fix: Avoid defaulting to silent login

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ React component for a simple login with Microsoft services, based on [Official M
 | debug                 | boolean                                            |                        | Boolean flag to enable detailed logs of authorization process.                                                                                                                                                                            |
 | className             | string                                             |                        | Additional class name string.                                                                                                                                                                                                             |
 | children              | ReactComponent                                     |                        | Alternative way to provide custom button element as a children prop instead of [Official Microsoft brand design](https://docs.microsoft.com/en-us/azure/active-directory/develop/howto-add-branding-in-azure-ad-apps)                     |
+| attemptSilentLogin | boolean | `false` | Set whether silent login should be attempted |
 
 ### Sign out
 

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "react-microsoft-login",
+  "name": "@zipteams/react-microsoft-login",
   "description": "React component for easy OAuth with Microsoft services on client side.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "version": "1.15.0",
-  "author": "alexandrtovmach@gmail.com",
-  "bugs": "https://github.com/alexandrtovmach/react-microsoft-login/issues",
+  "author": "Zipteams",
+  "bugs": "https://github.com/zipteams/react-microsoft-login/issues",
   "private": false,
   "scripts": {
     "watch": "tsc --watch",
@@ -15,10 +15,10 @@
     "prepare": "is-ci || husky install",
     "prettify": "prettier --write './src/**/*.{js,jsx,ts,tsx,json,css,md}'"
   },
-  "homepage": "https://alexandrtovmach.github.io/react-microsoft-login",
+  "homepage": "https://github.com/zipteams/react-microsoft-login#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/alexandrtovmach/react-microsoft-login.git"
+    "url": "https://github.com/zipteams/react-microsoft-login.git"
   },
   "dependencies": {
     "msal": "^1.3.2"

--- a/src/MicrosoftLogin.tsx
+++ b/src/MicrosoftLogin.tsx
@@ -86,6 +86,11 @@ interface MicrosoftLoginProps {
    * https://docs.microsoft.com/en-us/azure/active-directory/develop/msal-js-sso
    */
   useLocalStorageCache?: boolean;
+
+  /**
+   * Set whether silent login should be attempted
+   */
+  attemptSilentLogin?: boolean;
 }
 
 const MicrosoftLogin: React.FunctionComponent<MicrosoftLoginProps> = ({
@@ -103,6 +108,7 @@ const MicrosoftLogin: React.FunctionComponent<MicrosoftLoginProps> = ({
   prompt,
   debug,
   useLocalStorageCache,
+  attemptSilentLogin = false,
 }) => {
   const msalInstance = getUserAgentApp({
     clientId,
@@ -137,12 +143,15 @@ const MicrosoftLogin: React.FunctionComponent<MicrosoftLoginProps> = ({
   // attempt silent login
   // return msalInstance to user login handler on reload if token is present
   useEffect(() => {
+    if (!attemptSilentLogin) return;
+
     const clientToken = useLocalStorageCache
       ? localStorage.getItem("msal.idtoken")
       : sessionStorage.getItem("msal.idtoken");
 
-    clientToken && getGraphAPITokenAndUser(forceRedirectStrategy || checkToIE());
-  }, [msalInstance]);
+    clientToken &&
+      getGraphAPITokenAndUser(forceRedirectStrategy || checkToIE());
+  }, []);
 
   const login = () => {
     log("Login STARTED");


### PR DESCRIPTION
The component defaults to silent login, and has no way to control this behaviour. This is not the desired behaviour in many cases. Also it attempts a silent login every time `msalInstance` changes, this leads to infinite attempts in many cases.

Fix:
- Added a flag to control whether silent login should be attempted.
- silent login will be updated only when the component is mounted.

Fixes: #101 